### PR TITLE
Remove Unecessary Serde Rename

### DIFF
--- a/src/dtos/address.rs
+++ b/src/dtos/address.rs
@@ -5,6 +5,7 @@ use validator::Validate;
 use crate::{models::address::Address, utils::uuid::is_valid_uuid};
 
 #[derive(Validate, Debug, Default, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct RegisterAddressDTO {
     #[validate(length(
         min = 1,
@@ -46,14 +47,12 @@ pub struct RegisterAddressDTO {
         max = 8,
         message = "Zip code must have a minimum of 5 and a maximum of 8 characters"
     ))]
-    #[serde(rename = "zipCode")]
     pub zip_code: String,
 
     pub latitude: Option<BigDecimal>,
     pub longitude: Option<BigDecimal>,
 
     #[validate(custom(function = "is_valid_uuid", message = "City ID must be a valid UUID"))]
-    #[serde(rename = "cityId")]
     pub city_id: String,
 }
 
@@ -87,6 +86,7 @@ pub struct SaveAddressParamsDTO<T, B> {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct FilterAddressDTO {
     pub id: String,
     pub address: String,
@@ -94,14 +94,9 @@ pub struct FilterAddressDTO {
     pub neighbourhood: String,
     pub reference: Option<String>,
     pub complement: Option<String>,
-
-    #[serde(rename = "zipCode")]
     pub zip_code: String,
-
     pub latitude: Option<BigDecimal>,
     pub longitude: Option<BigDecimal>,
-
-    #[serde(rename = "cityId")]
     pub city_id: String,
 }
 

--- a/src/dtos/city.rs
+++ b/src/dtos/city.rs
@@ -9,11 +9,11 @@ pub struct RegisterCityDTO {
     #[validate(length(
         min = 1,
         max = 100,
-        message = "City name must have a maximum of 100 characters"
+        message = "Name must have a maximum of 100 characters"
     ))]
     pub name: String,
 
-    #[validate(length(min = 7, max = 7, message = "City code must be 7 characters long."))]
+    #[validate(length(min = 7, max = 7, message = "Code must be 7 characters long."))]
     pub code: String,
 
     pub state_id: String,

--- a/src/dtos/city.rs
+++ b/src/dtos/city.rs
@@ -4,6 +4,7 @@ use validator::Validate;
 use crate::models::city::City;
 
 #[derive(Validate, Debug, Default, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct RegisterCityDTO {
     #[validate(length(
         min = 1,
@@ -15,16 +16,15 @@ pub struct RegisterCityDTO {
     #[validate(length(min = 7, max = 7, message = "City code must be 7 characters long."))]
     pub code: String,
 
-    #[serde(rename = "stateId")]
     pub state_id: String,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct FilterCityDTO {
     pub id: String,
     pub name: String,
     pub code: String,
-    #[serde(rename = "stateId")]
     pub state_id: String,
 }
 

--- a/src/dtos/collaborator.rs
+++ b/src/dtos/collaborator.rs
@@ -21,11 +21,7 @@ pub struct RegisterCollaboratorDTO {
     ))]
     pub cpf: String,
 
-    #[validate(length(
-        min = 1,
-        max = 9,
-        message = "RG must have a maximum of 9 characters"
-    ))]
+    #[validate(length(min = 1, max = 9, message = "RG must have a maximum of 9 characters"))]
     pub rg: String,
 
     #[validate(email)]

--- a/src/dtos/collaborator.rs
+++ b/src/dtos/collaborator.rs
@@ -5,50 +5,44 @@ use validator::Validate;
 use crate::models::collaborator::Collaborator;
 
 #[derive(Validate, Debug, Default, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct RegisterCollaboratorDTO {
     #[validate(length(
         min = 1,
         max = 100,
-        message = "Collaborator name must have a maximum of 100 characters"
+        message = "Name must have a maximum of 100 characters"
     ))]
     pub name: String,
 
     #[validate(length(
         min = 1,
         max = 11,
-        message = "Collaborator CPF must have a maximum of 11 characters"
+        message = "CPF must have a maximum of 11 characters"
     ))]
     pub cpf: String,
 
     #[validate(length(
         min = 1,
         max = 9,
-        message = "Collaborator RG must have a maximum of 9 characters"
+        message = "RG must have a maximum of 9 characters"
     ))]
     pub rg: String,
 
     #[validate(email)]
     pub email: String,
-
-    #[serde(rename = "updatedAt")]
     pub updated_at: NaiveDateTime,
-
-    #[serde(rename = "createdAt")]
     pub crated_at: NaiveDateTime,
 }
 
 #[derive(Validate, Debug, Default, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct FilterCollaboratorDTO {
     pub id: String,
     pub name: String,
     pub cpf: String,
     pub rg: String,
     pub email: String,
-
-    #[serde(rename = "updatedAt")]
     pub updated_at: NaiveDateTime,
-
-    #[serde(rename = "createdAt")]
     pub crated_at: NaiveDateTime,
 }
 

--- a/src/dtos/country.rs
+++ b/src/dtos/country.rs
@@ -9,7 +9,7 @@ pub struct RegisterCountryDTO {
     #[validate(length(
         min = 1,
         max = 100,
-        message = "Country name must have a maximum of 100 characters"
+        message = "Name must have a maximum of 100 characters"
     ))]
     pub name: String,
 

--- a/src/dtos/country.rs
+++ b/src/dtos/country.rs
@@ -4,6 +4,7 @@ use validator::Validate;
 use crate::models::country::Country;
 
 #[derive(Validate, Debug, Default, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct RegisterCountryDTO {
     #[validate(length(
         min = 1,
@@ -13,27 +14,22 @@ pub struct RegisterCountryDTO {
     pub name: String,
 
     #[validate(length(min = 2, max = 2, message = "Alpha 2 code must be 2 characters long"))]
-    #[serde(rename = "alpha2")]
     pub alpha_2: String,
 
     #[validate(length(min = 3, max = 3, message = "Alpha 3 code must be 3 characters long"))]
-    #[serde(rename = "alpha3")]
     pub alpha_3: String,
 
     #[validate(length(min = 3, max = 3, message = "Numeric 3 code must be 3 characters long"))]
-    #[serde(rename = "numeric3")]
     pub numeric_3: String,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct FilterCountryDTO {
     pub id: String,
     pub name: String,
-    #[serde(rename = "alpha2")]
     pub alpha_2: String,
-    #[serde(rename = "alpha3")]
     pub alpha_3: String,
-    #[serde(rename = "numeric3")]
     pub numeric_3: String,
 }
 

--- a/src/dtos/state.rs
+++ b/src/dtos/state.rs
@@ -4,6 +4,7 @@ use validator::Validate;
 use crate::models::state::State;
 
 #[derive(Validate, Debug, Default, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct RegisterStateDTO {
     #[validate(length(
         min = 1,
@@ -15,16 +16,15 @@ pub struct RegisterStateDTO {
     #[validate(length(min = 2, max = 2, message = "State code must be 2 characters long."))]
     pub code: String,
 
-    #[serde(rename = "countryId")]
     pub country_id: String,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct FilterStateDTO {
     pub id: String,
     pub name: String,
     pub code: String,
-    #[serde(rename = "countryId")]
     pub country_id: String,
 }
 

--- a/src/dtos/state.rs
+++ b/src/dtos/state.rs
@@ -9,11 +9,11 @@ pub struct RegisterStateDTO {
     #[validate(length(
         min = 1,
         max = 100,
-        message = "State name must have a maximum of 100 characters"
+        message = "Name must have a maximum of 100 characters"
     ))]
     pub name: String,
 
-    #[validate(length(min = 2, max = 2, message = "State code must be 2 characters long."))]
+    #[validate(length(min = 2, max = 2, message = "Code must be 2 characters long."))]
     pub code: String,
 
     pub country_id: String,


### PR DESCRIPTION
## Description

Changed all the usages of `#[serde(rename = "")]` to a single `#[serde(rename_all = "")]` before the `struct` definition.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I ran `cargo clippy --all -- -D warnings` just before my last commit and fixed any issue that was found.
- [x] I ran `cargo fmt` just before my last commit.
- [x] I ran `cargo test` just before my last commit and all tests passed.
- [x] I added my algorithm to the corresponding `mod.rs` file within its own folder, and in any parent folder(s).
