### PR TITLE
Feature Request: Implement Route Status Scope

### DIFF
--- a/.sqlx/query-0572713f1245c7623ef3cf3e13be92cb30867070ad6feb247f5f42ef3b0a3eb9.json
+++ b/.sqlx/query-0572713f1245c7623ef3cf3e13be92cb30867070ad6feb247f5f42ef3b0a3eb9.json
@@ -1,0 +1,35 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO route_status (code, description) VALUES ($1, $2) RETURNING *",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "code",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "description",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Varchar",
+        "Varchar"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "0572713f1245c7623ef3cf3e13be92cb30867070ad6feb247f5f42ef3b0a3eb9"
+}

--- a/.sqlx/query-0a8ecfb85e9ad86a1d0e4cdb103000dff5effe287cf3ec5e4ff24159070cac91.json
+++ b/.sqlx/query-0a8ecfb85e9ad86a1d0e4cdb103000dff5effe287cf3ec5e4ff24159070cac91.json
@@ -1,0 +1,35 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT * FROM route_status LIMIT $1 OFFSET $2",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "code",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "description",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "0a8ecfb85e9ad86a1d0e4cdb103000dff5effe287cf3ec5e4ff24159070cac91"
+}

--- a/.sqlx/query-12be4a48094c476f5f78b55914ae524edafc8134a97c5d12092db67b4af8b2d9.json
+++ b/.sqlx/query-12be4a48094c476f5f78b55914ae524edafc8134a97c5d12092db67b4af8b2d9.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n            INSERT INTO routes (initial_lat, initial_long, final_lat, final_long, initial_address_id, final_address_id, vehicle_id) \n            VALUES ($1, $2, $3, $4, $5, $6, $7) \n            RETURNING *",
+  "query": "\n            INSERT INTO routes (initial_lat, initial_long, final_lat, final_long, initial_address_id, final_address_id, vehicle_id, status_id) \n            VALUES ($1, $2, $3, $4, $5, $6, $7, $8) \n            RETURNING *",
   "describe": {
     "columns": [
       {
@@ -67,6 +67,11 @@
         "ordinal": 12,
         "name": "vehicle_id",
         "type_info": "Uuid"
+      },
+      {
+        "ordinal": 13,
+        "name": "status_id",
+        "type_info": "Uuid"
       }
     ],
     "parameters": {
@@ -75,6 +80,7 @@
         "Numeric",
         "Numeric",
         "Numeric",
+        "Uuid",
         "Uuid",
         "Uuid",
         "Uuid"
@@ -89,12 +95,13 @@
       false,
       false,
       false,
-      false,
-      false,
       true,
       true,
+      true,
+      true,
+      false,
       false
     ]
   },
-  "hash": "d53097a9874bb9d3ab2cdafd188093dbf79d62a508e37466e596976065b79da9"
+  "hash": "12be4a48094c476f5f78b55914ae524edafc8134a97c5d12092db67b4af8b2d9"
 }

--- a/.sqlx/query-1e00a7d6c1cea07a3d4e86fc1668a1f0bba1196b3d6091fde4e2c55451f34f52.json
+++ b/.sqlx/query-1e00a7d6c1cea07a3d4e86fc1668a1f0bba1196b3d6091fde4e2c55451f34f52.json
@@ -1,0 +1,34 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT * FROM route_status WHERE code = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "code",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "description",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "1e00a7d6c1cea07a3d4e86fc1668a1f0bba1196b3d6091fde4e2c55451f34f52"
+}

--- a/.sqlx/query-28b803e1460d5ac91cd732d9ee4dd9d66e9d106b9bb4193a417d77ea27ad3b0a.json
+++ b/.sqlx/query-28b803e1460d5ac91cd732d9ee4dd9d66e9d106b9bb4193a417d77ea27ad3b0a.json
@@ -67,6 +67,11 @@
         "ordinal": 12,
         "name": "vehicle_id",
         "type_info": "Uuid"
+      },
+      {
+        "ordinal": 13,
+        "name": "status_id",
+        "type_info": "Uuid"
       }
     ],
     "parameters": {
@@ -84,10 +89,11 @@
       false,
       false,
       false,
-      false,
-      false,
       true,
       true,
+      true,
+      true,
+      false,
       false
     ]
   },

--- a/.sqlx/query-7f38af4fa3d7b4f66dca2d1c7b8d8cccf31fa15421384d2f1eec2e488a269b48.json
+++ b/.sqlx/query-7f38af4fa3d7b4f66dca2d1c7b8d8cccf31fa15421384d2f1eec2e488a269b48.json
@@ -1,0 +1,34 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT * FROM route_status WHERE id = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "code",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "description",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "7f38af4fa3d7b4f66dca2d1c7b8d8cccf31fa15421384d2f1eec2e488a269b48"
+}

--- a/.sqlx/query-a59a3d2bfa5087d382530d494a9704295bed2442a5c29b264a7b2c1841393057.json
+++ b/.sqlx/query-a59a3d2bfa5087d382530d494a9704295bed2442a5c29b264a7b2c1841393057.json
@@ -1,0 +1,34 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "DELETE FROM route_status WHERE id = $1 RETURNING *",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "code",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "description",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "a59a3d2bfa5087d382530d494a9704295bed2442a5c29b264a7b2c1841393057"
+}

--- a/.sqlx/query-b6a399f6b618e400442b967ceb8eaf51722f70a45001e81320e1667205983bb1.json
+++ b/.sqlx/query-b6a399f6b618e400442b967ceb8eaf51722f70a45001e81320e1667205983bb1.json
@@ -67,6 +67,11 @@
         "ordinal": 12,
         "name": "vehicle_id",
         "type_info": "Uuid"
+      },
+      {
+        "ordinal": 13,
+        "name": "status_id",
+        "type_info": "Uuid"
       }
     ],
     "parameters": {
@@ -83,10 +88,11 @@
       false,
       false,
       false,
-      false,
-      false,
       true,
       true,
+      true,
+      true,
+      false,
       false
     ]
   },

--- a/.sqlx/query-c593d86abe05265dcea5987e508a5b2d43aabb6270242060c7d57bd52d8b199b.json
+++ b/.sqlx/query-c593d86abe05265dcea5987e508a5b2d43aabb6270242060c7d57bd52d8b199b.json
@@ -67,6 +67,11 @@
         "ordinal": 12,
         "name": "vehicle_id",
         "type_info": "Uuid"
+      },
+      {
+        "ordinal": 13,
+        "name": "status_id",
+        "type_info": "Uuid"
       }
     ],
     "parameters": {
@@ -83,10 +88,11 @@
       false,
       false,
       false,
-      false,
-      false,
       true,
       true,
+      true,
+      true,
+      false,
       false
     ]
   },

--- a/migrations/20240608000724_route_status.down.sql
+++ b/migrations/20240608000724_route_status.down.sql
@@ -1,0 +1,2 @@
+-- Add down migration script here
+DROP TABLE IF EXISTS route_status;

--- a/migrations/20240608000724_route_status.up.sql
+++ b/migrations/20240608000724_route_status.up.sql
@@ -1,0 +1,7 @@
+-- Add up migration script here
+CREATE TABLE IF NOT EXISTS route_status
+(
+    id          UUID               NOT NULL PRIMARY KEY DEFAULT (uuid_generate_v4()),
+    code        VARCHAR(20) UNIQUE NOT NULL,
+    description VARCHAR(60)        NOT NULL
+);

--- a/migrations/20240608003354_route_add_route_id_column.down.sql
+++ b/migrations/20240608003354_route_add_route_id_column.down.sql
@@ -1,0 +1,19 @@
+BEGIN;
+
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 
+               FROM information_schema.columns 
+               WHERE table_name = 'routes' AND column_name = 'status_id') THEN
+        ALTER TABLE routes
+        DROP COLUMN status_id;
+    END IF;
+END $$;
+
+DO $$
+BEGIN
+    DELETE FROM route_status
+    WHERE code = 'CREATED';
+END $$;
+
+COMMIT;

--- a/migrations/20240608003354_route_add_route_id_column.up.sql
+++ b/migrations/20240608003354_route_add_route_id_column.up.sql
@@ -1,0 +1,25 @@
+-- Add up migration script here
+INSERT INTO route_status(code, description)
+VALUES ('CREATED', 'Rota criada')
+ON CONFLICT (code)
+    DO NOTHING;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_name = 'routes'
+          AND column_name = 'status_id'
+    ) THEN
+        ALTER TABLE IF EXISTS routes
+            ADD COLUMN status_id UUID
+                CONSTRAINT fk_routes_route_status REFERENCES route_status (id);
+    END IF;
+END $$;
+
+UPDATE routes
+SET status_id = (SELECT id FROM route_status WHERE code = 'CREATED')
+WHERE status_id IS NULL;
+
+ALTER TABLE IF EXISTS routes ALTER COLUMN status_id SET NOT NULL;

--- a/src/db/route.rs
+++ b/src/db/route.rs
@@ -131,7 +131,11 @@ pub trait RouteStatusExt {
         code: Option<String>,
     ) -> Result<Option<RouteStatus>, sqlx::Error>;
 
-    async fn list_all(&self, page: u32, limit: usize) -> Result<Vec<RouteStatus>, sqlx::Error>;
+    async fn list_route_status(
+        &self,
+        page: u32,
+        limit: usize,
+    ) -> Result<Vec<RouteStatus>, sqlx::Error>;
 
     async fn save_route_status<T: Into<String> + Send>(
         &self,
@@ -175,7 +179,11 @@ impl RouteStatusExt for DBClient {
         Ok(status)
     }
 
-    async fn list_all(&self, page: u32, limit: usize) -> Result<Vec<RouteStatus>, sqlx::Error> {
+    async fn list_route_status(
+        &self,
+        page: u32,
+        limit: usize,
+    ) -> Result<Vec<RouteStatus>, sqlx::Error> {
         let offset = (page - 1) * limit as u32;
 
         let statuses = sqlx::query_as!(

--- a/src/db/route.rs
+++ b/src/db/route.rs
@@ -3,7 +3,10 @@ use bigdecimal::BigDecimal;
 use sqlx::Error;
 use uuid::Uuid;
 
-use crate::{dtos::route::SaveRouteParamsDTO, models::route::Route};
+use crate::{
+    dtos::route::SaveRouteParamsDTO,
+    models::route::{Route, RouteStatus},
+};
 
 use super::client::DBClient;
 
@@ -59,6 +62,7 @@ impl RouteExt for DBClient {
             final_lat,
             final_long,
             // driver_id,
+            status_id,
             initial_address_id,
             final_address_id,
             vehicle_id,
@@ -77,11 +81,14 @@ impl RouteExt for DBClient {
         let vehicle_id = Uuid::parse_str(&vehicle_id.into())
             .map_err(|e| Error::Protocol(format!("Failed to parse vehicle_id: {}", e)))?;
 
+        let status_id = Uuid::parse_str(&status_id.into())
+            .map_err(|e| Error::Protocol(format!("Failed to parse status_id: {}", e)))?;
+
         let route = sqlx::query_as!(
             Route,
             r#"
-            INSERT INTO routes (initial_lat, initial_long, final_lat, final_long, initial_address_id, final_address_id, vehicle_id) 
-            VALUES ($1, $2, $3, $4, $5, $6, $7) 
+            INSERT INTO routes (initial_lat, initial_long, final_lat, final_long, initial_address_id, final_address_id, vehicle_id, status_id) 
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8) 
             RETURNING *"#,
             &initial_lat.into(),
             &initial_long.into(),
@@ -89,7 +96,8 @@ impl RouteExt for DBClient {
             &final_long.map(Into::into).unwrap_or_default(),
             initial_address_id,
             final_address_id,
-            vehicle_id,
+            &vehicle_id,
+            &status_id,
             // Uuid::parse_str(&driver_id.into()).unwrap(),
         )
         .fetch_one(&self.pool)
@@ -112,5 +120,109 @@ impl RouteExt for DBClient {
         }
 
         Ok(route)
+    }
+}
+
+#[async_trait]
+pub trait RouteStatusExt {
+    async fn get_route_status(
+        &self,
+        status_id: Option<Uuid>,
+        code: Option<String>,
+    ) -> Result<Option<RouteStatus>, sqlx::Error>;
+
+    async fn list_all(&self, page: u32, limit: usize) -> Result<Vec<RouteStatus>, sqlx::Error>;
+
+    async fn save_route_status<T: Into<String> + Send>(
+        &self,
+        code: Option<T>,
+        description: T,
+    ) -> Result<RouteStatus, sqlx::Error>;
+
+    async fn delete_route_status(
+        &self,
+        status_id: Option<Uuid>,
+    ) -> Result<Option<RouteStatus>, sqlx::Error>;
+}
+
+#[async_trait]
+impl RouteStatusExt for DBClient {
+    async fn get_route_status(
+        &self,
+        status_id: Option<Uuid>,
+        code: Option<String>,
+    ) -> Result<Option<RouteStatus>, sqlx::Error> {
+        let mut status = None;
+
+        if let Some(status_id) = status_id {
+            status = sqlx::query_as!(
+                RouteStatus,
+                r#"SELECT * FROM route_status WHERE id = $1"#,
+                status_id
+            )
+            .fetch_optional(&self.pool)
+            .await?;
+        } else if let Some(code) = code {
+            status = sqlx::query_as!(
+                RouteStatus,
+                r#"SELECT * FROM route_status WHERE code = $1"#,
+                code
+            )
+            .fetch_optional(&self.pool)
+            .await?;
+        }
+
+        Ok(status)
+    }
+
+    async fn list_all(&self, page: u32, limit: usize) -> Result<Vec<RouteStatus>, sqlx::Error> {
+        let offset = (page - 1) * limit as u32;
+
+        let statuses = sqlx::query_as!(
+            RouteStatus,
+            r#"SELECT * FROM route_status LIMIT $1 OFFSET $2"#,
+            limit as i64,
+            offset as i64
+        )
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(statuses)
+    }
+
+    async fn save_route_status<T: Into<String> + Send>(
+        &self,
+        code: Option<T>,
+        description: T,
+    ) -> Result<RouteStatus, sqlx::Error> {
+        let state = sqlx::query_as!(
+            RouteStatus,
+            r#"INSERT INTO route_status (code, description) VALUES ($1, $2) RETURNING *"#,
+            &code.map(Into::into).unwrap_or_default(),
+            &description.into(),
+        )
+        .fetch_one(&self.pool)
+        .await?;
+
+        Ok(state)
+    }
+
+    async fn delete_route_status(
+        &self,
+        status_id: Option<Uuid>,
+    ) -> Result<Option<RouteStatus>, sqlx::Error> {
+        let mut status = None;
+
+        if let Some(status_id) = status_id {
+            status = sqlx::query_as!(
+                RouteStatus,
+                r#"DELETE FROM route_status WHERE id = $1 RETURNING *"#,
+                status_id
+            )
+            .fetch_optional(&self.pool)
+            .await?;
+        }
+
+        Ok(status)
     }
 }

--- a/src/dtos/route.rs
+++ b/src/dtos/route.rs
@@ -3,7 +3,10 @@ use chrono::NaiveDateTime;
 use serde::{Deserialize, Serialize};
 use validator::Validate;
 
-use crate::{models::route::Route, utils::uuid::is_valid_uuid};
+use crate::{
+    models::route::{Route, RouteStatus},
+    utils::uuid::is_valid_uuid,
+};
 
 #[derive(Validate, Debug, Default, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -15,6 +18,13 @@ pub struct RegisterRouteDTO {
 
     // #[validate(custom(function = "is_valid_uuid", message = "Driver ID must be a valid UUID"))]
     // pub driver_id: String,
+    #[validate(length(
+        min = 1,
+        max = 20,
+        message = "Status must have a maximum of 20 characters"
+    ))]
+    pub status_id: String,
+
     #[validate(custom(
         function = "is_valid_uuid",
         message = "Initial address ID must be a valid UUID"
@@ -42,6 +52,7 @@ impl RegisterRouteDTO {
             final_lat: self.final_lat,
             final_long: self.final_long,
             // driver_id: self.driver_id,
+            status_id: self.status_id,
             initial_address_id: self.initial_address_id,
             final_address_id: self.final_address_id,
             vehicle_id: self.vehicle_id,
@@ -56,6 +67,7 @@ pub struct SaveRouteParamsDTO<B, S> {
     pub final_lat: Option<B>,
     pub final_long: Option<B>,
     // pub driver_id: S,
+    pub status_id: S,
     pub initial_address_id: Option<S>,
     pub final_address_id: Option<S>,
     pub vehicle_id: S,
@@ -75,6 +87,7 @@ pub struct FilterRouteDTO {
     pub final_lat: Option<BigDecimal>,
     pub final_long: Option<BigDecimal>,
     // pub driver_id: Uuid,
+    pub status_id: String,
     pub initial_address_id: Option<String>,
     pub final_address_id: Option<String>,
     pub vehicle_id: String,
@@ -102,6 +115,7 @@ impl FilterRouteDTO {
                 None
             },
             // driver_id: route.driver_id.to_string(),
+            status_id: route.status_id.to_string(),
             initial_address_id: route.initial_address_id.map(|id| id.to_string()),
             final_address_id: route.final_address_id.map(|id| id.to_string()),
             vehicle_id: route.vehicle_id.to_string(),
@@ -122,5 +136,47 @@ pub struct RouteResponseDTO {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct RouteListResponseDTO {
     pub routes: Vec<FilterRouteDTO>,
+    pub results: usize,
+}
+
+#[derive(Validate, Debug, Default, Clone, Serialize, Deserialize)]
+pub struct RegisterRouteStatusDTO {
+    pub code: Option<String>,
+    pub description: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct FilterRouteStatusDTO {
+    pub id: String,
+    pub code: String,
+    pub description: String,
+}
+
+impl FilterRouteStatusDTO {
+    pub fn filter_route_status(route: &RouteStatus) -> Self {
+        FilterRouteStatusDTO {
+            id: route.id.to_string(),
+            code: route.code.to_owned(),
+            description: route.description.to_owned(),
+        }
+    }
+
+    pub fn filter_route_statuses(states: &[RouteStatus]) -> Vec<FilterRouteStatusDTO> {
+        states
+            .iter()
+            .map(FilterRouteStatusDTO::filter_route_status)
+            .collect()
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct RouteStatusResponseDTO {
+    pub status: String,
+    pub data: FilterRouteStatusDTO,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct RouteStatusListResponseDTO {
+    pub status: Vec<FilterRouteStatusDTO>,
     pub results: usize,
 }

--- a/src/dtos/route.rs
+++ b/src/dtos/route.rs
@@ -122,8 +122,8 @@ impl FilterRouteDTO {
         }
     }
 
-    pub fn filter_routes(states: &[Route]) -> Vec<FilterRouteDTO> {
-        states.iter().map(FilterRouteDTO::filter_route).collect()
+    pub fn filter_routes(routes: &[Route]) -> Vec<FilterRouteDTO> {
+        routes.iter().map(FilterRouteDTO::filter_route).collect()
     }
 }
 
@@ -153,16 +153,16 @@ pub struct FilterRouteStatusDTO {
 }
 
 impl FilterRouteStatusDTO {
-    pub fn filter_route_status(route: &RouteStatus) -> Self {
+    pub fn filter_route_status(status: &RouteStatus) -> Self {
         FilterRouteStatusDTO {
-            id: route.id.to_string(),
-            code: route.code.to_owned(),
-            description: route.description.to_owned(),
+            id: status.id.to_string(),
+            code: status.code.to_owned(),
+            description: status.description.to_owned(),
         }
     }
 
-    pub fn filter_route_statuses(states: &[RouteStatus]) -> Vec<FilterRouteStatusDTO> {
-        states
+    pub fn filter_route_statuses(statuses: &[RouteStatus]) -> Vec<FilterRouteStatusDTO> {
+        statuses
             .iter()
             .map(FilterRouteStatusDTO::filter_route_status)
             .collect()

--- a/src/error.rs
+++ b/src/error.rs
@@ -46,6 +46,7 @@ pub enum ErrorMessage {
     VehicleDocumentExist,
     VehicleDocumentNotFound,
     RouteNotFound,
+    RouteStatusNotFound,
 }
 
 impl fmt::Display for ErrorMessage {
@@ -76,9 +77,10 @@ impl ErrorMessage {
             ErrorMessage::CollaboratorNotFound => "The collaborator with the provided ID, email or cpf does not exist in our ,records",
             ErrorMessage::VehicleExist => "There is already a vehicle with the provided data",
             ErrorMessage::VehicleNotFound => "The vehicle with the provided ID does not exist in our records",
-            ErrorMessage::VehicleDocumentExist => "There is already a document for the vehicle with the provided chassisNumber, ,registrationNumber or plate",
-            ErrorMessage::VehicleDocumentNotFound => "The document for the vehicle with the provided ID does not exist in our ,records",
+            ErrorMessage::VehicleDocumentExist => "There is already a document for the vehicle with the provided chassisNumber, registrationNumber or plate",
+            ErrorMessage::VehicleDocumentNotFound => "The document for the vehicle with the provided ID does not exist in our records",
             ErrorMessage::RouteNotFound => "There route with the provided ID does not exist in our records",
+            ErrorMessage::RouteStatusNotFound => "The status for the route with the provided ID does not exist in our records"
         }
     }
 
@@ -100,6 +102,7 @@ impl ErrorMessage {
             ErrorMessage::VehicleDocumentExist => "Verify the vehicle document details (chassisNumber, registrationNumber or plate) are unique and do not already exist.",
             ErrorMessage::VehicleDocumentNotFound => "Ensure the vehicleId, chassisNumber, registrationNumber or plate is correct and exists in the database. Use the 'GET /api/v1/vehicles' endpoint to retrieve available vehicle IDs and the 'GET /api/v1/vehicle{vehicleId}/documents' to retrieve the vehicle document.",
             ErrorMessage::RouteNotFound => "Ensure the routeId is correct and exists in the database. Use the 'GET /api/v1/routes' endpoint to retrieve available route IDs.",
+            ErrorMessage::RouteStatusNotFound => "Ensure the routeId is correct and exists in the database. Use the 'GET /api/v1/routes' endpoint to retrieve available route IDs."
         }
     }
 }

--- a/src/models/route.rs
+++ b/src/models/route.rs
@@ -17,7 +17,15 @@ pub struct Route {
     pub final_long: Option<BigDecimal>,
     // TODO: Waiting for the driver scope
     // pub driver_id: Uuid,
+    pub status_id: Uuid,
     pub initial_address_id: Option<Uuid>,
     pub final_address_id: Option<Uuid>,
     pub vehicle_id: Uuid,
+}
+
+#[derive(Debug, Deserialize, sqlx::FromRow, Serialize, Clone)]
+pub struct RouteStatus {
+    pub id: Uuid,
+    pub code: String,
+    pub description: String,
 }

--- a/src/scopes/route.rs
+++ b/src/scopes/route.rs
@@ -117,7 +117,7 @@ pub async fn delete_route(
 
 pub async fn get_route_status(
     id: web::Path<uuid::Uuid>,
-    app_state: web::Data<AppState>
+    app_state: web::Data<AppState>,
 ) -> Result<HttpResponse, HttpError> {
     let status = app_state
         .db_client

--- a/src/scopes/route.rs
+++ b/src/scopes/route.rs
@@ -5,7 +5,10 @@ use crate::{
     db::route::{RouteExt, RouteStatusExt},
     dtos::{
         request::RequestQueryDTO,
-        route::{FilterRouteDTO, FilterRouteStatusDTO, RegisterRouteDTO, RouteListResponseDTO},
+        route::{
+            FilterRouteDTO, FilterRouteStatusDTO, RegisterRouteDTO, RegisterRouteStatusDTO,
+            RouteListResponseDTO, RouteStatusListResponseDTO,
+        },
     },
     error::{ErrorMessage, HttpError},
     AppState,
@@ -14,8 +17,11 @@ use crate::{
 pub fn route_scope() -> Scope {
     web::scope("/api/v1/routes")
         .route("", web::get().to(list_routes))
-        .route("/{id}", web::get().to(get_route))
         .route("", web::post().to(save_route))
+        .route("/status", web::post().to(save_route_status))
+        .route("/status/{id}", web::delete().to(delete_route_status))
+        .route("/status", web::get().to(list_route_status))
+        .route("/{id}", web::get().to(get_route))
         .route("/{id}", web::delete().to(delete_route))
         .route("/{id}/status", web::get().to(get_route_status))
 }
@@ -110,7 +116,6 @@ pub async fn delete_route(
 
 pub async fn get_route_status(
     id: web::Path<uuid::Uuid>,
-    code: Option<String>,
     app_state: web::Data<AppState>,
 ) -> Result<HttpResponse, HttpError> {
     let route = app_state
@@ -124,7 +129,11 @@ pub async fn get_route_status(
         Some(route) => {
             status_id = route.status_id;
         }
-        None => return Err(HttpError::from_error_message(ErrorMessage::RouteStatusNotFound)),
+        None => {
+            return Err(HttpError::from_error_message(
+                ErrorMessage::RouteStatusNotFound,
+            ))
+        }
     }
 
     let status = app_state
@@ -137,6 +146,82 @@ pub async fn get_route_status(
         Some(status) => {
             Ok(HttpResponse::Ok().json(FilterRouteStatusDTO::filter_route_status(&status)))
         }
-        None => Err(HttpError::from_error_message(ErrorMessage::RouteStatusNotFound)),
+        None => Err(HttpError::from_error_message(
+            ErrorMessage::RouteStatusNotFound,
+        )),
+    }
+}
+
+pub async fn list_route_status(
+    query: web::Query<RequestQueryDTO>,
+    app_state: web::Data<AppState>,
+) -> Result<HttpResponse, HttpError> {
+    let query_params: RequestQueryDTO = query.into_inner();
+
+    query_params
+        .validate()
+        .map_err(|e| HttpError::bad_request(e.to_string()))?;
+
+    let page = query_params.page.unwrap_or(1);
+    let limit = query_params.limit.unwrap_or(50);
+
+    let statuses = app_state
+        .db_client
+        .list_route_status(page as u32, limit)
+        .await
+        .map_err(|e| HttpError::server_error(e.to_string()))?;
+
+    Ok(HttpResponse::Ok().json(RouteStatusListResponseDTO {
+        status: FilterRouteStatusDTO::filter_route_statuses(&statuses),
+        results: statuses.len(),
+    }))
+}
+
+pub async fn save_route_status(
+    app_state: web::Data<AppState>,
+    body: web::Json<RegisterRouteStatusDTO>,
+) -> Result<HttpResponse, HttpError> {
+    body.validate()
+        .map_err(|e| HttpError::bad_request(e.to_string()))?;
+
+    let result = app_state
+        .db_client
+        .save_route_status(body.code.as_ref(), &body.description)
+        .await;
+
+    match result {
+        Ok(status) => {
+            Ok(HttpResponse::Created().json(FilterRouteStatusDTO::filter_route_status(&status)))
+        }
+        Err(sqlx::Error::Database(db_err)) => {
+            if db_err.is_unique_violation() {
+                Err(HttpError::unique_constraint_violation(
+                    ErrorMessage::AddressExist,
+                ))
+            } else if db_err.is_foreign_key_violation() {
+                Err(HttpError::bad_request(ErrorMessage::CityNotFound))
+            } else {
+                Err(HttpError::server_error(db_err.to_string()))
+            }
+        }
+        Err(e) => Err(HttpError::server_error(e.to_string())),
+    }
+}
+
+pub async fn delete_route_status(
+    id: web::Path<uuid::Uuid>,
+    app_state: web::Data<AppState>,
+) -> Result<HttpResponse, HttpError> {
+    let status = app_state
+        .db_client
+        .delete_route_status(Some(id.into_inner()))
+        .await
+        .map_err(|e| HttpError::server_error(e.to_string()))?;
+
+    match status {
+        Some(status) => {
+            Ok(HttpResponse::Ok().json(FilterRouteStatusDTO::filter_route_status(&status)))
+        }
+        None => Err(HttpError::from_error_message(ErrorMessage::RouteNotFound)),
     }
 }


### PR DESCRIPTION
## Description

Implementation of the route status scope.

### Endpoints

| Method | Endpoint | Description |
| --- | --- | --- |
| GET | `/api/v1/routes/status` | List all the available route status. |
| GET | `/api/v1/routes/status/:statusId` | Returns the status referring to the given ID. |
| GET | `/api/v1/routes/:routeId/status` | Returns the status referring to the given route ID. |
| POST | `/api/v1/routes/staus` | Creates a route status. |
| DELETE | `/api/v1/routes/status/:statusId` | Deletes the route status. |

### Payloads

#### List all the available route status

##### Response

```json
{
    "status": [
        {
            "id": "a8449322-e5c9-47d5-89f8-d767172476a8",
            "code": "CREATED",
            "description": "Created"
        },
        {
            "id": "520aeebc-3a48-4875-8aea-a1bd2ce1369a",
            "code": "IN_PROGRESS",
            "description": "In progress"
        }
    ],
    "results": 2
}
```

#### Returns the status referring to the given ID (or route ID)

##### Response

```json
{
  "id": "a8449322-e5c9-47d5-89f8-d767172476a8",
  "code": "CREATED",
  "description": "Created"
}
```

#### Returns 

#### Creates a route status

##### Request

```json
{
    "code": "IN_PROGRESS",
    "description": "In progress"
}
```

##### Response

```json
{
  "id": "a8449322-e5c9-47d5-86f8-d5867972236a8",
  "code": "IN_PROGRESS",
  "description": "In progress"
}
```

#### Delete a route

##### Response

```json
{
  "id": "a8449322-e5c9-47d5-89f8-d767172476a8",
  "code": "CREATED",
  "description": "Created"
}
```

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I ran `cargo clippy --all -- -D warnings` just before my last commit and fixed any issue that was found.
- [x] I ran `cargo fmt --all -- --check` just before my last commit.
- [x] I ran `cargo test` just before my last commit and all tests passed.
- [x] I added my algorithm to the corresponding `mod.rs` file within its own folder, and in any parent folder(s).
